### PR TITLE
Fix error when parsing mods with commands in comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -299,7 +299,9 @@ MSpell.prepareData_PostMod = function() {
 				} else {
 					var u = modctx.unitlookup[uid];
 					if (!u) {
-						console.log('Unit '+uid+' not found (Spell '+_o.id+')');
+						if (uid > 0) {
+							console.log('Unit '+uid+' not found (Spell '+_o.id+')');
+						}
 						break;
 					}
 

--- a/scripts/parsemod.js
+++ b/scripts/parsemod.js
@@ -79,7 +79,7 @@ function lookupTruncation(longname, object, minlen) {
 	while (longname.length > minlen) { 
 		longname = longname.substr(0, longname.length-1);
 		if (object[longname])
-			return longname; 
+			return longname;
 	}
 	return null;
 }
@@ -714,7 +714,12 @@ var modctx = DMI.modctx = {
 		uwok:		_bool,
 		
 		secondaryeffect:	_ref,
-		secondaryeffectalways:	_ref
+		secondaryeffectalways:	_ref,
+
+		natural: _bool,
+		internal: _bool,
+		ferrous: _bool,
+		flammable: _bool
 		
 
 	},
@@ -968,7 +973,12 @@ var modctx = DMI.modctx = {
 		summerpower:	_num,
 		fallpower:	_num,
 		winterpower:	_num,
-		
+
+		chaospower: _num,
+		deathpower: _num,
+		magicpower: _num,
+		slothpower: _num,
+
 		ambidextrous:	_num,
 		banefireshield:	_num,
 		berserk:	_num,
@@ -1153,7 +1163,6 @@ var modctx = DMI.modctx = {
 
 		voidsanity:		_num,
 		invulnerable:	_num,
-		magicpower:		_num,
 		randomspell:	_num,
 		reclimit:		_num,
 		homerealm: 		function(c,a,t){ modctx[t]['realms'].push(argref(a)); },
@@ -1174,7 +1183,6 @@ var modctx = DMI.modctx = {
 		deathdisease:	_num,
 		deathparalyze:	_num,
 		deathfire:		_num,
-		chaospower:		_num,
 		digest:			_num,
 		incorporate:	_num,
 		incprovdef:		_num,
@@ -1226,7 +1234,6 @@ var modctx = DMI.modctx = {
 		iceforging:		_num,
 		guardspiritbonus:	_num,
 
-		spy:			_bool,
 		slowrec:		_bool,
 		noslowrec:		_bool,
 		reqlab:			_bool,
@@ -1278,6 +1285,12 @@ var modctx = DMI.modctx = {
 		batstartsum3d6:	_ref,
 		batstartsum4d6:	_ref,
 		batstartsum5d6:	_ref,
+
+		fixedresearch: _num,
+		slothresearch: _num,
+		transformation: _num,
+		undcommand: _num,
+		magiccommand: _num,
 
 	},
 
@@ -1382,7 +1395,7 @@ var modctx = DMI.modctx = {
 	//nation selected
 	nationcommands: {
 		end: function(c,a,t){ modctx[t] = null; },
-		
+
 		clearnation: function(c,a,t) {
 			var o = modctx.nation;
 			var keepstats = {
@@ -1431,6 +1444,10 @@ var modctx = DMI.modctx = {
 				}
 			}
 		},
+		clear: function(c,a,t) {
+			modctx.nationcommands.clearnation(c,a,t);
+		},
+
 		//units
 		startcom: _ignore,//_ref,
 		startscout: _ignore,//_ref,
@@ -1808,7 +1825,10 @@ modctx.parseMod = function(str, modnum, modname) {
 	for (var i=0; i<lines.length; i++) {
 		var cstr = lines[i], linenum = i+1;
 		var cmd, args;
-		
+
+		// check for comments
+		if (cstr.startsWith('--')) continue;
+
 		//check for open quote
 		var a = modcom_re_multistr.exec(lines[i]);
 		if (a) {

--- a/scripts/parsemod.js
+++ b/scripts/parsemod.js
@@ -1191,7 +1191,7 @@ var modctx = DMI.modctx = {
 		bodyguard:		_num,
 		masterrit:		_num,
 		inspiringres:	_num,
-		divineins:		_num,
+		divineins:		_bool,
 		firerange:		_num,
 		airrange:		_num,
 		waterrange:		_num,


### PR DESCRIPTION
There was a bug where commented out commands were still being parsed. This led to nationgen mods not loading properly. Fixed in a dumb way (ignoring lines starting with "--") which covers most situations. There could still be problems if a comment starts later in a line.

In addition I've added support for the #clear command for nations (which is undocumented but appears to work), and added a load of new modding commands to the valid list. This was mostly to stop them clogging up the log file, so I haven't done proper descriptions for them, but they're displayed at least.